### PR TITLE
Support setting rp_filter mode

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -242,6 +242,8 @@ neutron_logging_debug: "{{ openstack_logging_debug }}"
 
 openstack_neutron_auth: "{{ openstack_auth }}"
 
+neutron_l3_agent_host_rp_filter_mode: 0
+
 ####################
 # Extension drivers
 ####################

--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -6,8 +6,8 @@
   sysctl: name={{ item.name }} value={{ item.value }} sysctl_set=yes
   with_items:
     - { name: "net.ipv4.ip_forward", value: 1}
-    - { name: "net.ipv4.conf.all.rp_filter", value: 0}
-    - { name: "net.ipv4.conf.default.rp_filter", value: 0}
+    - { name: "net.ipv4.conf.all.rp_filter", value: "{{ neutron_l3_agent_host_rp_filter_mode }}"}
+    - { name: "net.ipv4.conf.default.rp_filter", value: "{{ neutron_l3_agent_host_rp_filter_mode }}"}
   when:
     - set_sysctl | bool
     - (neutron_l3_agent.enabled | bool and neutron_l3_agent.host_in_groups | bool)

--- a/ansible/roles/nova/defaults/main.yml
+++ b/ansible/roles/nova/defaults/main.yml
@@ -277,6 +277,7 @@ nova_logging_debug: "{{ openstack_logging_debug }}"
 openstack_nova_auth: "{{ openstack_auth }}"
 openstack_placement_auth: "{{ openstack_auth }}"
 
+nova_compute_host_rp_filter_mode: 0
 
 nova_libvirt_port: "16509"
 nova_ssh_port: "8022"

--- a/ansible/roles/nova/tasks/config.yml
+++ b/ansible/roles/nova/tasks/config.yml
@@ -5,8 +5,8 @@
   with_items:
     - { name: "net.bridge.bridge-nf-call-iptables", value: 1}
     - { name: "net.bridge.bridge-nf-call-ip6tables", value: 1}
-    - { name: "net.ipv4.conf.all.rp_filter", value: 0}
-    - { name: "net.ipv4.conf.default.rp_filter", value: 0}
+    - { name: "net.ipv4.conf.all.rp_filter", value: "{{ nova_compute_host_rp_filter_mode }}"}
+    - { name: "net.ipv4.conf.default.rp_filter", value: "{{ nova_compute_host_rp_filter_mode }}"}
   when:
     - set_sysctl | bool
     - inventory_hostname in groups['compute']


### PR DESCRIPTION
We may also want this in queens..

Enables setting rp_filter mode on Neutron L3 agent and Nova compute
hosts whilst maintaining the default that it is disabled.

Closes-Bug: #1782799
Change-Id: I93e53bad9727beb786b00bd7fcd6d78785c619c2